### PR TITLE
[Fix] Stario version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -43,6 +43,6 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'androidx.annotation:annotation:1.1.0'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.7'
-    implementation 'com.starmicronics:stario:2.8.0'
-    implementation 'com.starmicronics:starioextension:1.14.0'
+    implementation 'com.starmicronics:stario:2.11.1'
+    implementation 'com.starmicronics:starioextension:1.15.1'
 }


### PR DESCRIPTION
The version of stario (official SDK) has been updated to work properly with the mC-Print3 series.